### PR TITLE
Fix failure for cases when subpage contains an extra slash

### DIFF
--- a/src/BySubpageLinksFinder.php
+++ b/src/BySubpageLinksFinder.php
@@ -80,8 +80,12 @@ class BySubpageLinksFinder {
 		array_pop( $links );
 
 		foreach ( $links as $link ) {
-			$growinglink .= $link;
-			$this->antecedentHierarchyLinks[] = DIWikiPage::newFromTitle( Title::newFromText( $growinglink ) );
+
+			if ( $link !== '' ) {
+				$growinglink .= $link;
+				$this->antecedentHierarchyLinks[] = DIWikiPage::newFromTitle( Title::newFromText( $growinglink ) );
+			}
+
 			$growinglink .= '/';
 		}
 	}

--- a/tests/phpunit/Unit/BySubpageLinksFinderTest.php
+++ b/tests/phpunit/Unit/BySubpageLinksFinderTest.php
@@ -105,6 +105,25 @@ class BySubpageLinksFinderTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		#4 /a/b
+		$provider[] = array(
+			'/a/b',
+			1,
+			array(
+				new DIWikiPage( '/a', NS_MAIN )
+			)
+		);
+
+		#5 /a//b/c
+		$provider[] = array(
+			'/a//b/c',
+			2,
+			array(
+				new DIWikiPage( '/a', NS_MAIN ),
+				new DIWikiPage( '/a//b', NS_MAIN )
+			)
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
Ensures that "/a/b", "/a//b/c" are handled correctly.