### PR TITLE
Auto create "Has parent page" for subpages

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,6 +31,10 @@ enabled then SBL will not try to resolve a possible subpage hierarchy.
 of a subpage title from display when a corresponding namespace entry is found in the
 [`wgNamespacesWithSubpages`][mw-nssubp] setting.
 
+- `$GLOBALS['egSBLEnabledSubpageParentAnnotation']` supports the auto-generation of `Has parent page`
+annotations for subpages. Yet, it will not create any additional assignment if `Has parent page` is
+already part of the `SemanticData`.
+
 ## Default settings
 
 ```php
@@ -38,6 +42,7 @@ $GLOBALS['egSBLBreadcrumbTrailStyleClass'] = 'sbl-breadcrumb-trail-light';
 $GLOBALS['egSBLBreadcrumbDividerStyleClass'] = 'sbl-breadcrumb-arrow';
 
 $GLOBALS['egSBLPageTitleToHideSubpageParent'] = true;
+$GLOBALS['egSBLEnabledSubpageParentAnnotation'] = true;
 
 $GLOBALS['egSBLTryToFindClosestDescendant'] = true;
 $GLOBALS['egSBLUseSubpageFinderFallback'] = true;
@@ -48,24 +53,28 @@ $GLOBALS['egSBLPropertySearchPatternByNamespace'] = array(
 	NS_CATEGORY => array(
 		'_SUBC',
 		'_SUBC',
-		'_SUBC' ),
+		'_SUBC'
+	),
 
 	// Search for a three level sub-property hierarchy
 	SMW_NS_PROPERTY => array(
 		'_SUBP',
 		'_SUBP',
-		'_SUBP' ),
+		'_SUBP'
+	),
 
 	// Search for a three level antecedent hierarchy that contains a `Has parent page`
 	// annotation to follow a `parent > grandparent > great-grandparent` schema
 	NS_MAIN => array(
 		SBL_PROP_PARENTPAGE,
 		SBL_PROP_PARENTPAGE,
-		SBL_PROP_PARENTPAGE ),
+		SBL_PROP_PARENTPAGE
+	),
 	NS_HELP => array(
 		SBL_PROP_PARENTPAGE,
 		SBL_PROP_PARENTPAGE,
-		SBL_PROP_PARENTPAGE )
+		SBL_PROP_PARENTPAGE
+	)
 );
 ```
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,8 @@ This file contains the RELEASE-NOTES of the Semantic Breadcrumb Links (a.k.a. SB
 
 ### 1.3.0 (2015-03-10)
 
+* Added `$GLOBALS['egSBLEnabledSubpageParentAnnotation']` to allow for subpage
+  parents to be annotated automatically if no other `Has parent page` exists
 * Recognize `egSBLPageTitleToHideSubpageParent` / `wgNamespacesWithSubpages`
   when building the breadcrumb title
 * Apply italic styles for "hasChildren" early to avoid JS async display clutter

--- a/SemanticBreadcrumbLinks.php
+++ b/SemanticBreadcrumbLinks.php
@@ -73,6 +73,7 @@ call_user_func( function () {
 	$GLOBALS['egSBLTryToFindClosestDescendant'] = true;
 	$GLOBALS['egSBLUseSubpageFinderFallback'] = true;
 	$GLOBALS['egSBLPageTitleToHideSubpageParent'] = true;
+	$GLOBALS['egSBLEnabledSubpageParentAnnotation'] = true;
 
 	// Finalize registration process
 	$GLOBALS['wgExtensionFunctions'][] = function() {
@@ -108,6 +109,7 @@ call_user_func( function () {
 			'breadcrumbDividerStyleClass' => $GLOBALS['egSBLBreadcrumbDividerStyleClass'],
 			'tryToFindClosestDescendant' => $GLOBALS['egSBLTryToFindClosestDescendant'],
 			'useSubpageFinderFallback' => $GLOBALS['egSBLUseSubpageFinderFallback'],
+			'enabledSubpageParentAnnotation' => $GLOBALS['egSBLEnabledSubpageParentAnnotation'],
 			'wgNamespacesWithSubpages' => $GLOBALS['wgNamespacesWithSubpages'],
 			'propertySearchPatternByNamespace' => $GLOBALS['egSBLPropertySearchPatternByNamespace'] + $defaultPropertySearchPatternByNamespace
 		);

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -3,6 +3,7 @@
 namespace SBL;
 
 use SMW\Store;
+use SMW\ApplicationFactory;
 use DummyLinker;
 use Hooks;
 
@@ -131,6 +132,35 @@ class HookRegistry {
 			);
 
 			$pageDisplayOutputModifier->modifyOutput( $output );
+
+			return true;
+		};
+
+		/**
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserAfterTidy
+		 */
+		$this->handlers['ParserAfterTidy'] = function ( &$parser, &$text ) use ( $options ) {
+
+			// ParserOptions::getInterfaceMessage is being used to identify whether a
+			// parse was initiated by `Message::parse`
+			if ( $parser->getTitle()->isSpecialPage() || $parser->getOptions()->getInterfaceMessage() ) {
+				return true;
+			}
+
+			$parserData = ApplicationFactory::getInstance()->newParserData(
+				$parser->getTitle(),
+				$parser->getOutput()
+			);
+
+			$subpageParentAnnotator = new SubpageParentAnnotator(
+				$parserData
+			);
+
+			$subpageParentAnnotator->setSubpageParentAnnotationState(
+				$options->get( 'enabledSubpageParentAnnotation' )
+			);
+
+			$subpageParentAnnotator->addAnnotation();
 
 			return true;
 		};

--- a/src/SubpageParentAnnotator.php
+++ b/src/SubpageParentAnnotator.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SBL;
+
+use SMW\DIWikiPage;
+use SMW\ParserData;
+use SMW\DIProperty;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 1.3
+ *
+ * @author mwjames
+ */
+class SubpageParentAnnotator {
+
+	/**
+	 * @var ParserData
+	 */
+	private $parserData;
+
+	/**
+	 * @var boolean
+	 */
+	private $subpageParentAnnotationState = true;
+
+	/**
+	 * @since 1.3
+	 *
+	 * @param ParserData $parserData
+	 */
+	public function __construct( ParserData $parserData ) {
+		$this->parserData = $parserData;
+	}
+
+	/**
+	 * @since 1.3
+	 *
+	 * @param boolean $subpageParentAnnotationState
+	 */
+	public function setSubpageParentAnnotationState( $subpageParentAnnotationState ) {
+		$this->subpageParentAnnotationState = (bool)$subpageParentAnnotationState;
+	}
+
+	/**
+	 * @since  1.3
+	 */
+	public function addAnnotation() {
+
+		$title = $this->parserData->getTitle();
+
+		if ( !$this->subpageParentAnnotationState || strpos( $title->getText(), '/' ) === false ) {
+			return;
+		}
+
+		$property = DIProperty::newFromUserLabel( SBL_PROP_PARENTPAGE );
+
+		// Don't override any "man"-made annotation
+		if ( $this->parserData->getSemanticData()->getPropertyValues( $property ) !== array() ) {
+			return;
+		}
+
+		$this->parserData->getSemanticData()->addPropertyObjectValue(
+			$property,
+			DIWikiPage::newFromText( $this->getBaseText( $title ), $title->getNamespace() )
+		);
+
+		$this->parserData->pushSemanticDataToParserOutput();
+	}
+
+	// Don't rely on Title::getBaseText as it depends on the wgNamespacesWithSubpages
+	// setting and if set false will return the normal text including its subparts
+	private function getBaseText( $title ) {
+
+		$parts = explode( '/', $title->getText() );
+		# Don't discard the real title if there's no subpage involved
+		if ( count( $parts ) > 1 ) {
+			unset( $parts[count( $parts ) - 1] );
+		}
+
+		return implode( '/', $parts );
+	}
+
+}

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -64,6 +64,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			'breadcrumbTrailStyleClass' => 'foo',
 			'breadcrumbDividerStyleClass' => 'bar',
 			'hideSubpageParent' => true,
+			'enabledSubpageParentAnnotation' => true,
 			'wgNamespacesWithSubpages' => array()
 		);
 
@@ -77,6 +78,8 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestInitProperties( $instance );
 		$this->doTestSkinTemplateOutputPageBeforeExec( $instance, $skin );
 		$this->doTestBeforePageDisplay( $instance, $outputPage, $skin );
+		$this->doTestParserAfterTidy( $instance );
+		$this->doTestParserAfterTidyToBailOutEarly( $instance );
 	}
 
 	private function doTestInitProperties( $instance ) {
@@ -120,6 +123,90 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			array( &$outputPage, &$skin )
+		);
+	}
+
+	private function doTestParserAfterTidy( $instance ) {
+
+		$handler = 'ParserAfterTidy';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$parserOptions = $this->getMockBuilder( '\ParserOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser = $this->getMockBuilder( '\Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$parser->expects( $this->any() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $parserOptions ) );
+
+		$parser->expects( $this->any() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$text = '';
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( &$parser, &$text )
+		);
+	}
+
+	private function doTestParserAfterTidyToBailOutEarly( $instance ) {
+
+		$handler = 'ParserAfterTidy';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$parserOptions = $this->getMockBuilder( '\ParserOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOptions->expects( $this->any() )
+			->method( 'getInterfaceMessage' )
+			->will( $this->returnValue( true ) );
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser = $this->getMockBuilder( '\Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$parser->expects( $this->any() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $parserOptions ) );
+
+		$text = '';
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( &$parser, &$text )
 		);
 	}
 

--- a/tests/phpunit/Unit/HtmlBreadcrumbLinksBuilderTest.php
+++ b/tests/phpunit/Unit/HtmlBreadcrumbLinksBuilderTest.php
@@ -49,10 +49,14 @@ class HtmlBreadcrumbLinksBuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new HtmlBreadcrumbLinksBuilder( $byPropertyHierarchicalLinksFinder, $bySubpageLinksFinder );
+		$instance = new HtmlBreadcrumbLinksBuilder(
+			$byPropertyHierarchicalLinksFinder,
+			$bySubpageLinksFinder
+		);
 
 		$instance->setBreadcrumbTrailStyleClass( 'Foo' );
 		$instance->setLinker( $dummyLinker );
+		$instance->setHideSubpageParentState( true );
 
 		$this->assertInternalType(
 			'string',

--- a/tests/phpunit/Unit/SubpageParentAnnotatorTest.php
+++ b/tests/phpunit/Unit/SubpageParentAnnotatorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SBL\Tests;
+
+use SBL\SubpageParentAnnotator;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use Title;
+
+/**
+ * @covers \SBL\SubpageParentAnnotator
+ * @group semantic-breadcrumb-links
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class SubpageParentAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $parserData;
+
+	protected function setUp() {
+
+		$title = Title::newFromText( 'Foo/Bar' );
+
+		$this->parserData = $this->getMockBuilder( '\SMW\ParserData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parserData->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SBL\SubpageParentAnnotator',
+			new SubpageParentAnnotator( $this->parserData )
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$property = DIProperty::newFromUserLabel( SBL_PROP_PARENTPAGE );
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array() ) );
+
+		$semanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' )
+			->with(
+				$this->equalTo( $property ),
+				$this->equalTo( $subject ) );
+
+		$this->parserData->expects( $this->atLeastOnce() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$instance = new SubpageParentAnnotator(
+			$this->parserData
+		);
+
+		$instance->addAnnotation();
+	}
+
+	public function testDisabledAnnotationFunctionality() {
+
+		$this->parserData->expects( $this->never() )
+			->method( 'getSemanticData' );
+
+		$instance = new SubpageParentAnnotator(
+			$this->parserData
+		);
+
+		$instance->setSubpageParentAnnotationState( false );
+		$instance->addAnnotation();
+	}
+
+	public function testDisabledAnnotationFunctionalityDueToPreexisingValues() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( 'Foo' ) ) );
+
+		$semanticData->expects( $this->never() )
+			->method( 'addPropertyObjectValue' );
+
+		$this->parserData->expects( $this->atLeastOnce() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$instance = new SubpageParentAnnotator(
+			$this->parserData
+		);
+
+		$instance->setSubpageParentAnnotationState( true );
+		$instance->addAnnotation();
+	}
+
+}


### PR DESCRIPTION
If `$GLOBALS['egSBLEnabledSubpageParentAnnotation']` is enabled then the "Has parent page" property is added in an auto process allowing quickly to navigate subpages without the need to create child annotations by-hand.

The process is not applied for when "Has parent page" does pre-exist.