### PR TITLE
Update SemanticBreadcrumbLinks.php

### DIFF
--- a/SemanticBreadcrumbLinks.php
+++ b/SemanticBreadcrumbLinks.php
@@ -47,7 +47,7 @@ class SemanticBreadcrumbLinks {
 
 		// Register the extension
 		$GLOBALS['wgExtensionCredits']['semantic'][ ] = array(
-			'path'           => __DIR__,
+			'path'           => __FILE__,
 			'name'           => 'Semantic Breadcrumb Links',
 			'author'         => array( 'James Hong Kong' ),
 			'url'            => 'https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/',


### PR DESCRIPTION
Allow the git hash and time stamp of the version to be shown on "Special:Version"

Refs issue https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/issues/19