### PR TITLE
Add `__NOBREADCRUMBLINKS__`, refs 29

### DIFF
--- a/SemanticBreadcrumbLinks.php
+++ b/SemanticBreadcrumbLinks.php
@@ -67,6 +67,7 @@ class SemanticBreadcrumbLinks {
 
 		// Register message files
 		$GLOBALS['wgMessagesDirs']['SemanticBreadcrumbLinks'] = __DIR__ . '/i18n';
+		$GLOBALS['wgExtensionMessagesFiles']['SemanticBreadcrumbLinksMagic'] = __DIR__ . '/i18n/SemanticBreadcrumbLinks.magic.php';
 
 		// Register resource files
 		$GLOBALS['wgResourceModules']['ext.semanticbreadcrumblinks.styles'] = array(

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,10 @@ a parental relationship with `Foo` then the breadcrumb trail for `Baz` will be r
 `Foo > Bar`. On the other hand, the subject `Bar` will display a `Foo > Bar < Baz` trail
 indicating that `Foo` is a `parent`( `>` ) and `Baz` is a `child` ( `<` ) of `Bar`.
 
+Using `__NOBREADCRUMBLINKS__` on an individual page will suppress the __display__ of a SBL
+generated breadcrumb trail, yet it will not remove or alter the state of annotation related
+values.
+
 ### Configuration
 
 Details on available sttings are decribed in [this](00-configurations.md) document.

--- a/i18n/SemanticBreadcrumbLinks.magic.php
+++ b/i18n/SemanticBreadcrumbLinks.magic.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Magic words
+ */
+$magicWords = array();
+
+/**
+ * English (English)
+ */
+$magicWords['en'] = array(
+	'SBL_NOBREADCRUMBLINKS' => array( 0, '__NOBREADCRUMBLINKS__' )
+);
+

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -78,6 +78,25 @@ class HookRegistry {
 		};
 
 		/**
+		 * @see https://www.semantic-mediawiki.org/wiki/Hooks/SMW::Parser::BeforeMagicWordsFinder
+		 */
+		$this->handlers['SMW::Parser::BeforeMagicWordsFinder'] = function( array &$magicWords ) {
+			$magicWords = array_merge( $magicWords, array( 'SBL_NOBREADCRUMBLINKS' ) );
+			return true;
+		};
+
+		/**
+		 * @note This is bit of a hack but there is no other way to get access to
+		 * the ParserOutput
+		 *
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/OutputPageParserOutput
+		 */
+		$this->handlers['OutputPageParserOutput'] = function( &$outputPage, $parserOutput ) {
+			$outputPage->smwmagicwords = $parserOutput->getExtensionData( 'smwmagicwords' );
+			return true;
+		};
+
+		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateOutputPageBeforeExec
 		 */
 		$this->handlers['SkinTemplateOutputPageBeforeExec'] = function ( &$skin, &$template ) use( $store, $options ) {

--- a/src/SkinTemplateOutputModifier.php
+++ b/src/SkinTemplateOutputModifier.php
@@ -62,6 +62,10 @@ class SkinTemplateOutputModifier {
 			return false;
 		}
 
+		if ( isset( $output->smwmagicwords ) && in_array( 'SBL_NOBREADCRUMBLINKS', $output->smwmagicwords ) ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -80,6 +80,8 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestBeforePageDisplay( $instance, $outputPage, $skin );
 		$this->doTestParserAfterTidy( $instance );
 		$this->doTestParserAfterTidyToBailOutEarly( $instance );
+		$this->doTestSmwParserBeforeMagicWordsFinder( $instance );
+		$this->doTestOutputPageParserOutput( $instance, $outputPage );
 	}
 
 	private function doTestInitProperties( $instance ) {
@@ -211,6 +213,52 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			array( &$parser, &$text )
+		);
+	}
+
+	private function doTestSmwParserBeforeMagicWordsFinder( $instance ) {
+
+		$handler = 'SMW::Parser::BeforeMagicWordsFinder';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$magicWords = array();
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( &$magicWords )
+		);
+
+		$this->assertContains(
+			'SBL_NOBREADCRUMBLINKS',
+			$magicWords
+		);
+	}
+
+	private function doTestOutputPageParserOutput( $instance, $outputPage ) {
+
+		$handler = 'OutputPageParserOutput';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$magicWords = array();
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( &$outputPage, $parserOutput )
+		);
+
+		$this->assertEquals(
+			'',
+			$outputPage->smwmagicwords
 		);
 	}
 

--- a/tests/phpunit/Unit/SkinTemplateOutputModifierTest.php
+++ b/tests/phpunit/Unit/SkinTemplateOutputModifierTest.php
@@ -29,7 +29,7 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testForUnknownTitle() {
+	public function testTryPrependHtmlOnUnknownTitle() {
 
 		$htmlBreadcrumbLinksBuilder = $this->getMockBuilder( '\SBL\HtmlBreadcrumbLinksBuilder' )
 			->disableOriginalConstructor()
@@ -54,14 +54,16 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$instance = new SkinTemplateOutputModifier( $htmlBreadcrumbLinksBuilder );
+		$instance = new SkinTemplateOutputModifier(
+			$htmlBreadcrumbLinksBuilder
+		);
 
 		$this->assertTrue(
 			$instance->modifyOutput( $output )
 		);
 	}
 
-	public function testForIsSpecialPage() {
+	public function testTryPrependHtmlOnSpecialPage() {
 
 		$htmlBreadcrumbLinksBuilder = $this->getMockBuilder( '\SBL\HtmlBreadcrumbLinksBuilder' )
 			->disableOriginalConstructor()
@@ -90,14 +92,16 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$instance = new SkinTemplateOutputModifier( $htmlBreadcrumbLinksBuilder );
+		$instance = new SkinTemplateOutputModifier(
+			$htmlBreadcrumbLinksBuilder
+		);
 
 		$this->assertTrue(
 			$instance->modifyOutput( $output )
 		);
 	}
 
-	public function testTryPrependHtmlForNonViewAction() {
+	public function testTryPrependHtmlOnNonViewAction() {
 
 		$context = new \RequestContext();
 		$context->setRequest( new \FauxRequest( array( 'action' => 'edit' ), true ) );
@@ -138,7 +142,58 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
+		$instance = new SkinTemplateOutputModifier(
+			$htmlBreadcrumbLinksBuilder
+		);
+
+		$this->assertTrue(
+			$instance->modifyOutput( $output )
+		);
+	}
+
+	public function testTryPrependHtmlOnNOBREADCRUMBLINKS() {
+
+		$context = new \RequestContext();
+		$context->setRequest( new \FauxRequest( array( 'action' => 'view'  ), true ) );
+
+		$htmlBreadcrumbLinksBuilder = $this->getMockBuilder( '\SBL\HtmlBreadcrumbLinksBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'isKnown' )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$title->expects( $this->once() )
+			->method( 'isSpecialPage' )
+			->will( $this->returnValue( false ) );
+
+		$output = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$output->expects( $this->never() )
+			->method( 'prependHTML' );
+
+		$output->expects( $this->once() )
+			->method( 'getContext' )
+			->will( $this->returnValue( $context ) );
+
+		$output->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
 		$instance = new SkinTemplateOutputModifier( $htmlBreadcrumbLinksBuilder );
+
+		$output->smwmagicwords = array( 'SBL_NOBREADCRUMBLINKS' );
 
 		$this->assertTrue(
 			$instance->modifyOutput( $output )


### PR DESCRIPTION
Using `__NOBREADCRUMBLINKS__` on an individual page will suppress the display of a SBL generated breadcrumb trail.

refs #29