### PR TITLE
Use `subtitle` to modify the skin template

### DIFF
--- a/res/sbl.styles.css
+++ b/res/sbl.styles.css
@@ -77,6 +77,14 @@
 	margin: .3em 0 0 0.6em;
 }
 
+/**
+ * @see the contentSub CSS, substract -1em to start from 0
+ */
+#contentSub #sbl-breadcrumbs {
+	font-size: 100%;
+	margin: 0 0 1.4em -1em;
+}
+
 /* SBL chameleon */
 .skin-chameleon .sbl-breadcrumb-children-list {
     margin: .1em 0 0 -1.5em;

--- a/src/ByPropertyHierarchicalLinksFinder.php
+++ b/src/ByPropertyHierarchicalLinksFinder.php
@@ -83,6 +83,7 @@ class ByPropertyHierarchicalLinksFinder {
 
 		$requestOptions = new RequestOptions();
 		$requestOptions->sort = true;
+		$requestOptions->conditionConstraint = true;
 
 		// Use 3 as buffer to broaden match possibilities
 		$requestOptions->limit = 3;

--- a/src/BySubpageLinksFinder.php
+++ b/src/BySubpageLinksFinder.php
@@ -48,13 +48,17 @@ class BySubpageLinksFinder {
 	 */
 	public function findLinksBySubject( DIWikiPage $subject ) {
 
-		$prefixedText = $subject->getTitle()->getPrefixedText();
+		$title = $subject->getTitle();
 
-		if ( !$this->canBuildLinksFromText( $prefixedText ) ) {
+		// Use the text instead of the prefixedText to avoid a split
+		// in cases where the NS contains a / (e.g. smw/schema:Foobar)
+		$text = $title->getText();
+
+		if ( !$this->canBuildLinksFromText( $text ) ) {
 			return;
 		}
 
-		$this->buildHierarchicalLinksFromText( $prefixedText );
+		$this->buildHierarchicalLinksFromText( $text, $title->getNamespace() );
 	}
 
 	/**
@@ -70,7 +74,7 @@ class BySubpageLinksFinder {
 		return preg_match( '/\//', $text );
 	}
 
-	private function buildHierarchicalLinksFromText( $text ) {
+	private function buildHierarchicalLinksFromText( $text, $ns ) {
 
 		$growinglink = '';
 		$links = explode( '/', $text );
@@ -82,7 +86,7 @@ class BySubpageLinksFinder {
 
 			if ( $link !== '' && substr( $link, -1 ) !== ' ' ) {
 				$growinglink .= $link;
-				$this->antecedentHierarchyLinks[] = DIWikiPage::newFromTitle( Title::newFromText( $growinglink ) );
+				$this->antecedentHierarchyLinks[] = DIWikiPage::newFromTitle( Title::newFromText( $growinglink, $ns ) );
 			}
 
 			$growinglink .= '/';

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -133,9 +133,12 @@ class HookRegistry {
 				$options->get( 'hideSubpageParent' )
 			);
 
-			$skinTemplateOutputModifier = new SkinTemplateOutputModifier( $htmlBreadcrumbLinksBuilder );
-			$skinTemplateOutputModifier->modifyTemplate( $template );
-			$skinTemplateOutputModifier->modifyOutput( $skin->getOutput() );
+			$skinTemplateOutputModifier = new SkinTemplateOutputModifier(
+				$htmlBreadcrumbLinksBuilder,
+				ApplicationFactory::getInstance()->getNamespaceExaminer()
+			);
+
+			$skinTemplateOutputModifier->modify( $skin->getOutput(), $template );
 
 			return true;
 		};

--- a/src/SkinTemplateOutputModifier.php
+++ b/src/SkinTemplateOutputModifier.php
@@ -3,6 +3,7 @@
 namespace SBL;
 
 use SMW\ApplicationFactory;
+use SMW\NamespaceExaminer;
 use OutputPage;
 use Action;
 use Title;
@@ -21,44 +22,52 @@ class SkinTemplateOutputModifier {
 	private $htmlBreadcrumbLinksBuilder;
 
 	/**
+	 * @var NnamespaceExaminer
+	 */
+	private $namespaceExaminer;
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param HtmlBreadcrumbLinksBuilder $htmlBreadcrumbLinksBuilder
+	 * @param NamespaceExaminer $namespaceExaminer
 	 */
-	public function __construct( HtmlBreadcrumbLinksBuilder $htmlBreadcrumbLinksBuilder ) {
+	public function __construct( HtmlBreadcrumbLinksBuilder $htmlBreadcrumbLinksBuilder, NamespaceExaminer $namespaceExaminer ) {
 		$this->htmlBreadcrumbLinksBuilder = $htmlBreadcrumbLinksBuilder;
+		$this->namespaceExaminer = $namespaceExaminer;
 	}
 
 	/**
-	 * @since  1.0
+	 * @since 1.5
 	 *
 	 * @param OutputPage $output
-	 *
-	 * @return boolean
-	 */
-	public function modifyOutput( OutputPage $output ) {
-		return $this->canModifyOutput( $output ) ? $this->doModifyOutput( $output ) : true;
-	}
-
-	/**
-	 * @since  1.0
-	 *
 	 * @param &$template
 	 */
-	public function modifyTemplate( &$template ) {
+	public function modify( OutputPage $output, &$template ) {
 
-		// Always set subtitle to be empty when SBL is used to avoid any output
-		// distraction
-		$template->data['subtitle'] = '';
+		if ( !$this->canModifyOutput( $output ) ) {
+			return;
+		}
+
+		$title = $output->getTitle();
+		$this->htmlBreadcrumbLinksBuilder->buildBreadcrumbs( $title );
+
+		$this->htmlBreadcrumbLinksBuilder->isRTL(
+			$title->getPageLanguage()->isRTL()
+		);
+
+		if ( !isset( $template->data['subtitle'] ) ) {
+			$template->data['subtitle'] = '';
+		}
+
+		// We always assume `subtitle` is available!
+		// https://github.com/wikimedia/mediawiki/blob/23ea2e4c2966f381eb7fd69b66a8d738bb24cc60/includes/skins/SkinTemplate.php#L292-L296
+		$template->data['subtitle'] = $this->htmlBreadcrumbLinksBuilder->getHtml();
 	}
 
 	private function canModifyOutput( OutputPage $output ) {
 
 		if ( !$this->isEnabled( $output->getTitle() ) ) {
-			return false;
-		}
-
-		if ( Action::getActionName( $output->getContext() ) !== 'view' ) {
 			return false;
 		}
 
@@ -69,23 +78,8 @@ class SkinTemplateOutputModifier {
 		return true;
 	}
 
-	private function doModifyOutput( OutputPage $output ) {
-
-		$this->htmlBreadcrumbLinksBuilder->buildBreadcrumbs( $output->getTitle() );
-
-		$this->htmlBreadcrumbLinksBuilder->isRTL(
-			$output->getTitle()->getPageLanguage()->isRTL()
-		);
-
-		$output->prependHTML( $this->htmlBreadcrumbLinksBuilder->getHtml() );
-
-		return true;
-	}
-
 	private function isEnabled( Title $title ) {
-		return $title->isKnown() &&
-			!$title->isSpecialPage() &&
-			ApplicationFactory::getInstance()->getNamespaceExaminer()->isSemanticEnabled( $title->getNamespace() );
+		return $title->isKnown() && !$title->isSpecialPage() && $this->namespaceExaminer->isSemanticEnabled( $title->getNamespace() );
 	}
 
 }

--- a/tests/phpunit/Unit/BySubpageLinksFinderTest.php
+++ b/tests/phpunit/Unit/BySubpageLinksFinderTest.php
@@ -38,7 +38,7 @@ class BySubpageLinksFinderTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider titleProvider
 	 */
-	public function testFindParentBreadcrumbs( $title,$count, $expected ) {
+	public function testFindParentBreadcrumbs( $title, $count, $expected ) {
 
 		$subject = DIWikiPage::newFromTitle( Title::newFromText( $title ) );
 
@@ -140,6 +140,15 @@ class BySubpageLinksFinderTest extends \PHPUnit_Framework_TestCase {
 			'Foo /Bar /Foobar',
 			0,
 			[]
+		];
+
+		#9
+		$provider[] = [
+			'Help:Foo/Foobar',
+			1,
+			[
+				new DIWikiPage( 'Foo', NS_HELP ),
+			]
 		];
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #46, #43

This PR addresses or contains:

- Instead of emptying `subtitle` use it to host the breadcrumbs
- Restores display of breadcrumbs for MW 1.30+

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #43
