### PR TITLE
Append `subtitle` but hide MW's subpages, refs 46

### DIFF
--- a/res/sbl.styles.css
+++ b/res/sbl.styles.css
@@ -85,6 +85,10 @@
 	margin: 0.9em 0 1.4em -1em;
 }
 
+#contentSub span.subpages {
+	display: none;
+}
+
 /* SBL chameleon */
 .skin-chameleon .sbl-breadcrumb-children-list {
     margin: .1em 0 0 -1.5em;

--- a/src/SkinTemplateOutputModifier.php
+++ b/src/SkinTemplateOutputModifier.php
@@ -62,7 +62,7 @@ class SkinTemplateOutputModifier {
 
 		// We always assume `subtitle` is available!
 		// https://github.com/wikimedia/mediawiki/blob/23ea2e4c2966f381eb7fd69b66a8d738bb24cc60/includes/skins/SkinTemplate.php#L292-L296
-		$template->data['subtitle'] = $this->htmlBreadcrumbLinksBuilder->getHtml();
+		$template->data['subtitle'] .= $this->htmlBreadcrumbLinksBuilder->getHtml();
 	}
 
 	private function canModifyOutput( OutputPage $output ) {

--- a/tests/phpunit/Unit/SkinTemplateOutputModifierTest.php
+++ b/tests/phpunit/Unit/SkinTemplateOutputModifierTest.php
@@ -100,9 +100,6 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$output->expects( $this->never() )
-			->method( 'prependHTML' );
-
 		$output->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
@@ -119,10 +116,6 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function PrependHtmlOnNonViewAction() {
-
-		$context = new \RequestContext();
-		$context->setRequest( new \FauxRequest( [ 'action' => 'edit' ], true ) );
-		$context->setTitle( Title::newFromText( __METHOD__ ) );
 
 		$htmlBreadcrumbLinksBuilder = $this->getMockBuilder( '\SBL\HtmlBreadcrumbLinksBuilder' )
 			->disableOriginalConstructor()
@@ -147,13 +140,6 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 		$output = $this->getMockBuilder( '\OutputPage' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$output->expects( $this->never() )
-			->method( 'prependHTML' );
-
-		$output->expects( $this->once() )
-			->method( 'getContext' )
-			->will( $this->returnValue( $context ) );
 
 		$output->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
@@ -172,9 +158,6 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 
 	public function testTryPrependHtmlOnNOBREADCRUMBLINKS() {
 
-		$context = new \RequestContext();
-		$context->setRequest( new \FauxRequest( [ 'action' => 'view'  ], true ) );
-
 		$htmlBreadcrumbLinksBuilder = $this->getMockBuilder( '\SBL\HtmlBreadcrumbLinksBuilder' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -199,13 +182,6 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$output->expects( $this->never() )
-			->method( 'prependHTML' );
-
-		$output->expects( $this->any() )
-			->method( 'getContext' )
-			->will( $this->returnValue( $context ) );
-
 		$output->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
@@ -223,10 +199,11 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 		$instance->modify( $output, $template );
 	}
 
-	public function tesPrependHtmlForViewActionOnly() {
+	public function testAppendHtml() {
 
-		$context = new \RequestContext();
-		$context->setRequest( new \FauxRequest( [ 'action' => 'view'  ], true ) );
+		$this->namespaceExaminer->expects( $this->once() )
+			->method( 'isSemanticEnabled' )
+			->will( $this->returnValue( true ) );
 
 		$htmlBreadcrumbLinksBuilder = $this->getMockBuilder( '\SBL\HtmlBreadcrumbLinksBuilder' )
 			->disableOriginalConstructor()
@@ -235,6 +212,10 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 		$htmlBreadcrumbLinksBuilder->expects( $this->once() )
 			->method( 'buildBreadcrumbs' )
 			->will( $this->returnSelf() );
+
+		$htmlBreadcrumbLinksBuilder->expects( $this->once() )
+			->method( 'getHtml' )
+			->will( $this->returnValue( 'bar' ) );
 
 		$language = $this->getMockBuilder( '\Language' )
 			->disableOriginalConstructor()
@@ -264,13 +245,6 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$output->expects( $this->once() )
-			->method( 'prependHTML' );
-
-		$output->expects( $this->once() )
-			->method( 'getContext' )
-			->will( $this->returnValue( $context ) );
-
 		$output->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
@@ -281,11 +255,15 @@ class SkinTemplateOutputModifierTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$template = new \stdClass;
-		$template->data = [];
+
+		$template->data = [
+			'subtitle' => 'Foo'
+		];
 
 		$instance->modify( $output, $template );
 
-		$this->assertEmpty(
+		$this->assertEquals(
+			'Foobar',
 			$template->data['subtitle']
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #46

This PR addresses or contains:

- Instead of replacing `subtitle`, append the content of it but hide MW's subpages 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #46