### PR TITLE
Disable translation subpage annotation

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -51,3 +51,8 @@ $GLOBALS['egSBLPageTitleToHideSubpageParent'] = true;
  * Supports the auto-generation of Has parent page annotations for subpages.
  */
 $GLOBALS['egSBLEnabledSubpageParentAnnotation'] = true;
+
+/**
+ * Disables the annotation for a subpage when it is identified as translation page.
+ */
+$GLOBALS['egSBLDisableTranslationSubpageAnnotation'] = true;

--- a/SemanticBreadcrumbLinks.php
+++ b/SemanticBreadcrumbLinks.php
@@ -153,6 +153,7 @@ class SemanticBreadcrumbLinks {
 			'tryToFindClosestDescendant' => $GLOBALS['egSBLTryToFindClosestDescendant'],
 			'useSubpageFinderFallback' => $GLOBALS['egSBLUseSubpageFinderFallback'],
 			'enabledSubpageParentAnnotation' => $GLOBALS['egSBLEnabledSubpageParentAnnotation'],
+			'disableTranslationSubpageAnnotation' => $GLOBALS['egSBLDisableTranslationSubpageAnnotation'],
 			'wgNamespacesWithSubpages' => $GLOBALS['wgNamespacesWithSubpages'],
 			'propertySearchPatternByNamespace' => $GLOBALS['egSBLPropertySearchPatternByNamespace'] + $defaultPropertySearchPatternByNamespace
 		];

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -187,6 +187,10 @@ class HookRegistry {
 				$options->get( 'enabledSubpageParentAnnotation' )
 			);
 
+			$subpageParentAnnotator->disableTranslationSubpageAnnotation(
+				$options->get( 'disableTranslationSubpageAnnotation' )
+			);
+
 			$subpageParentAnnotator->addAnnotation();
 
 			return true;

--- a/src/SubpageParentAnnotator.php
+++ b/src/SubpageParentAnnotator.php
@@ -26,6 +26,11 @@ class SubpageParentAnnotator {
 	private $enableSubpageParentAnnotation = true;
 
 	/**
+	 * @var boolean
+	 */
+	private $disableTranslationSubpageAnnotation = false;
+
+	/**
 	 * @since 1.3
 	 *
 	 * @param ParserData $parserData
@@ -44,6 +49,15 @@ class SubpageParentAnnotator {
 	}
 
 	/**
+	 * @since 1.3
+	 *
+	 * @param boolean $enableSubpageParentAnnotation
+	 */
+	public function disableTranslationSubpageAnnotation( $disableTranslationSubpageAnnotation ) {
+		$this->disableTranslationSubpageAnnotation = (bool)$disableTranslationSubpageAnnotation;
+	}
+
+	/**
 	 * @since  1.3
 	 */
 	public function addAnnotation() {
@@ -51,6 +65,12 @@ class SubpageParentAnnotator {
 		$title = $this->parserData->getTitle();
 
 		if ( !$this->enableSubpageParentAnnotation || strpos( $title->getText(), '/' ) === false ) {
+			return;
+		}
+
+		// Is a ranslation page? bail-out!
+		// @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3293
+		if ( $this->disableTranslationSubpageAnnotation && $this->parserData->getOutput()->getExtensionData( 'translate-translation-page' ) ) {
 			return;
 		}
 

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -65,6 +65,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			'breadcrumbDividerStyleClass' => 'bar',
 			'hideSubpageParent' => true,
 			'enabledSubpageParentAnnotation' => true,
+			'disableTranslationSubpageAnnotation' => false,
 			'wgNamespacesWithSubpages' => []
 		];
 

--- a/tests/phpunit/Unit/OptionsTest.php
+++ b/tests/phpunit/Unit/OptionsTest.php
@@ -3,6 +3,7 @@
 namespace SBL\Tests;
 
 use SBL\Options;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SBL\Options
@@ -14,6 +15,8 @@ use SBL\Options;
  * @author mwjames
  */
 class OptionsTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -29,11 +29,11 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyRegistry->expects( $this->any() )
+		$propertyRegistry->expects( $this->atLeastOnce() )
 			->method( 'registerProperty' )
 			->with( $this->equalTo( PropertyRegistry::SBL_PARENTPAGE ) );
 
-		$propertyRegistry->expects( $this->any() )
+		$propertyRegistry->expects( $this->atLeastOnce() )
 			->method( 'registerPropertyAlias' )
 			->with( $this->equalTo( PropertyRegistry::SBL_PARENTPAGE ) );
 

--- a/tests/phpunit/Unit/SubpageParentAnnotatorTest.php
+++ b/tests/phpunit/Unit/SubpageParentAnnotatorTest.php
@@ -19,10 +19,15 @@ use Title;
 class SubpageParentAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 	private $parserData;
+	private $parserOutput;
 
 	protected function setUp() {
 
 		$title = Title::newFromText( 'Foo/Bar' );
+
+		$this->parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->parserData = $this->getMockBuilder( '\SMW\ParserData' )
 			->disableOriginalConstructor()
@@ -31,6 +36,10 @@ class SubpageParentAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		$this->parserData->expects( $this->any() )
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
+
+		$this->parserData->expects( $this->any() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $this->parserOutput ) );
 	}
 
 	public function testCanConstruct() {
@@ -141,6 +150,21 @@ class SubpageParentAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->enableSubpageParentAnnotation( true );
+		$instance->addAnnotation();
+	}
+
+	public function testDisableTranslationSubpageAnnotation() {
+
+		$this->parserOutput->expects( $this->once() )
+			->method( 'getExtensionData' )
+			->with( $this->equalTo( 'translate-translation-page' ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new SubpageParentAnnotator(
+			$this->parserData
+		);
+
+		$instance->disableTranslationSubpageAnnotation( true );
 		$instance->addAnnotation();
 	}
 


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3293

This PR addresses or contains:

- Adds `$GLOBALS['egSBLDisableTranslationSubpageAnnotation']` and is set to `true` as default
- Avoids to create annotations for pages like `Foo/en` where `en` is identified as translation page by the Translation extension
- Works for any new translation revision but not for revisions in retrospect (aka existing translation pages)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
