### PR TITLE
Support extension.json, SBL 2.0.0

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -15,7 +15,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 /**
  * Assigns a styling class to the breadcrumb trail
  */
-$GLOBALS['egSBLBreadcrumbTrailStyleClass'] = 'sbl-breadcrumb-trail-light';
+$GLOBALS['sblgBreadcrumbTrailStyleClass'] = 'sbl-breadcrumb-trail-light';
 
 /**
  * Assigns a divider styling class

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"require": {
 		"php": ">=5.6",
 		"composer/installers": "1.*,>=1.0.12",
-		"mediawiki/semantic-media-wiki": "~2.4|~3.0",
+		"mediawiki/semantic-media-wiki": "~2.5|~3.0",
 		"onoi/shared-resources":"~0.2"
 	},
 	"require-dev": {
@@ -37,7 +37,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.x-dev"
+			"dev-master": "2.0.x-dev"
 		}
 	},
 	"autoload": {
@@ -52,6 +52,7 @@
 		"process-timeout": 0
 	},
 	"scripts":{
+		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist"
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,27 @@
+{
+	"name": "SemanticBreadcrumbLinks",
+	"version": "2.0.0-alpha",
+	"author": [
+		"James Hong Kong",
+		"..."
+	],
+	"url": "https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/",
+	"descriptionmsg": "sbl-desc",
+	"namemsg": "sbl-name",
+	"license-name": "GPL-2.0-or-later",
+	"type": "semantic",
+	"requires": {
+		"MediaWiki": ">= 1.27"
+	},
+	"MessagesDirs": {
+		"SemanticBreadcrumbLinks": [
+			"i18n"
+		]
+	},
+	"callback": "SemanticBreadcrumbLinks::initExtension",
+	"ExtensionFunctions": [
+		"SemanticBreadcrumbLinks::onExtensionFunction"
+	],
+	"load_composer_autoloader":true,
+	"manifest_version": 1
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,7 +6,12 @@
 		]
 	},
 	"sbl-desc": "A [https://www.semantic-mediawiki.org Semantic MediaWiki] extension to build breadcrumb links from an attributive property filter",
-	"smw-pa-property-predefined__sbl_parentpage": "\"$1\" is a predefined property that can describe a relationship between a parent and a child entity and is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Breadcrumb_Links Semantic Breadcrumb Links] extension.",
-	"smw-pa-property-predefined-long__sbl_parentpage": "By identifying the location of an entity relative to its parent it can be used to generate a navigational help in form of a breadcrumb trail.",
-	"sbl-property-alias-parentpage": "Has parent page"
+	"sbl-name": "Semantic Breadcrumb Links",
+	"smw-pa-property-predefined-sbl-parentpage": "\"$1\" is a predefined property that can describe a relationship between a parent and a child entity and is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Breadcrumb_Links Semantic Breadcrumb Links] extension.",
+	"smw-pa-property-predefined-long-sbl-parentpage": "By identifying the location of an entity relative to its parent it can be used to generate a navigational help in form of a breadcrumb trail.",
+	"sbl-property-alias-parentpage": "Has parent page",
+	"sbl-admin-deprecation-notice-section": "Semantic Breadcrumb Links extension",
+	"sbl-admin-deprecation-notice-title-replacement": "Replaced or renamed settings",
+	"sbl-admin-deprecation-notice-title-replacement-explanation": "The following section contains settings that were renamed or otherwise modified and it is recommended to forthwith update their name or format.",
+	"sbl-admin-deprecation-notice-config-replacement": "<code>[https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Breadcrumb_Links/$1 $1]</code> was replaced by <code>[https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Breadcrumb_Links/$2 $2]</code>"
 }

--- a/tests/travis/install-semantic-breadcrumb-links.sh
+++ b/tests/travis/install-semantic-breadcrumb-links.sh
@@ -52,9 +52,10 @@ function updateConfiguration {
 	echo '$wgShowExceptionDetails = true;' >> LocalSettings.php
 	echo '$wgDevelopmentWarnings = true;' >> LocalSettings.php
 	echo "putenv( 'MW_INSTALL_PATH=$(pwd)' );" >> LocalSettings.php
-	
+
 	# SMW#1732
 	echo 'wfLoadExtension( "SemanticMediaWiki" );' >> LocalSettings.php
+	echo 'wfLoadExtension( "SemanticBreadcrumbLinks" );' >> LocalSettings.php
 
 	php maintenance/update.php --quick
 }


### PR DESCRIPTION
This PR is made in reference to:

This PR addresses or contains:

- Adds support for `extension.json` and hereby makes `wfLoadExtension( "SemanticBreadcrumbLinks" );` a necessary setting
- Switches to 2.0.0 as version
- Example of moving settings and create deprecated notice `$GLOBALS['smwgDeprecationNotices']['sbl']` (see https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3438)
  - `egSBLBreadcrumbTrailStyleClass` -> `sblgBreadcrumbTrailStyleClass`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
