### PR TITLE
Fix warnings issued by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
+os:
+  - linux
 
 language: php
 
 services:
   - mysql
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - env: DB=mysql; MW=REL1_28; TYPE=coverage


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- root: key matrix is an alias for jobs, using jobs
- root: missing os, using the default linux

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
