### PR TITLE
Allow installation with SMW 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	"require": {
 		"php": ">=5.6",
 		"composer/installers": "1.*,>=1.0.12",
-		"mediawiki/semantic-media-wiki": "~2.5|~3.0",
+		"mediawiki/semantic-media-wiki": "~2.5|~3.0|~4.0",
 		"onoi/shared-resources":"~0.2"
 	},
 	"require-dev": {


### PR DESCRIPTION
Note that this does not mean that the extension is compatible with SMW 4. Note also that this does not mean that the next release should support PHP 5 and or SMW 2.5 (this is another pull)