### PR TITLE
Made it work again for 1.39

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This [video](https://vimeo.com/129347298) demonstrates the functionality of the 
 
 ## Requirements
 
-- PHP 8.1 or later
+- PHP 7.4 or later
 - MediaWiki 1.39 or later
 - [Semantic MediaWiki][smw] 4.2 or later
 

--- a/SemanticBreadcrumbLinks.php
+++ b/SemanticBreadcrumbLinks.php
@@ -86,14 +86,6 @@ class SemanticBreadcrumbLinks {
 	 * @since 1.3
 	 */
 	public static function onExtensionFunction() {
-		if ( !defined( 'SMW_VERSION' ) ) {
-			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {
-				die( "\nThe 'Semantic Breadcrumb Links' extension requires 'Semantic MediaWiki' to be installed and enabled.\n" );
-			} else {
-				die( '<b>Error:</b> The <a href="https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/">Semantic Breadcrumb Links</a> extension requires <a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki">Semantic MediaWiki</a> to be installed and enabled.<br />' );
-			}
-		}
-
 		// Default values are defined at this point to ensure
 		// NS contants are specified prior
 		$defaultPropertySearchPatternByNamespace = [

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks"
 	},
 	"require": {
-		"php": ">=8.1",
+		"php": ">=7.4",
 		"composer/installers": ">=1.0.1",
 		"onoi/shared-resources":"~0.2"
 	},

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"version": "2.1.0-alpha",
 	"author": [
 		"James Hong Kong",
-		"..."
+		"Youri van den Bogert <yvdbogert@archixl.nl>"
 	],
 	"url": "https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/",
 	"descriptionmsg": "sbl-desc",
@@ -11,7 +11,10 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.39"
+		"MediaWiki": ">= 1.39",
+		"extensions": {
+			"SemanticMediaWiki": ">= 4"
+		}
 	},
 	"MessagesDirs": {
 		"SemanticBreadcrumbLinks": [

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -99,7 +99,7 @@ class HookRegistry {
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinSubPageSubtitle
 		 */
-		$this->handlers['SkinSubPageSubtitle'] = function ( &$subpages, \Skin $skin ) use( $store, $options ) {
+		$this->handlers['SkinSubPageSubtitle'] = static function ( &$subpages, \Skin $skin ) use( $store, $options ) {
 			$bySubpageLinksFinder = new BySubpageLinksFinder();
 			$bySubpageLinksFinder->setSubpageDiscoveryFallback(
 				$options->get( 'useSubpageFinderFallback' )

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -97,9 +97,9 @@ class HookRegistry {
 		};
 
 		/**
-		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateOutputPageBeforeExec
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinSubPageSubtitle
 		 */
-		$this->handlers['SkinTemplateOutputPageBeforeExec'] = static function ( &$skin, &$template ) use( $store, $options ) {
+		$this->handlers['SkinSubPageSubtitle'] = function ( &$subpages, \Skin $skin ) use( $store, $options ) {
 			$bySubpageLinksFinder = new BySubpageLinksFinder();
 			$bySubpageLinksFinder->setSubpageDiscoveryFallback(
 				$options->get( 'useSubpageFinderFallback' )
@@ -137,7 +137,7 @@ class HookRegistry {
 				ApplicationFactory::getInstance()->getNamespaceExaminer()
 			);
 
-			$skinTemplateOutputModifier->modify( $skin->getOutput(), $template );
+			$skinTemplateOutputModifier->modify( $skin->getOutput(), $subpages );
 
 			return true;
 		};

--- a/src/SkinTemplateOutputModifier.php
+++ b/src/SkinTemplateOutputModifier.php
@@ -36,12 +36,12 @@ class SkinTemplateOutputModifier {
 	}
 
 	/**
-	 * @since 1.5
+	 * @since 2.1
 	 *
 	 * @param OutputPage $output
-	 * @param &$template
+	 * @param &$subpages
 	 */
-	public function modify( OutputPage $output, &$template ) {
+	public function modify( OutputPage $output, &$subpages ) {
 		if ( !$this->canModifyOutput( $output ) ) {
 			return;
 		}
@@ -53,13 +53,7 @@ class SkinTemplateOutputModifier {
 			$title->getPageLanguage()->isRTL()
 		);
 
-		if ( !isset( $template->data['subtitle'] ) ) {
-			$template->data['subtitle'] = '';
-		}
-
-		// We always assume `subtitle` is available!
-		// https://github.com/wikimedia/mediawiki/blob/23ea2e4c2966f381eb7fd69b66a8d738bb24cc60/includes/skins/SkinTemplate.php#L292-L296
-		$template->data['subtitle'] .= $this->htmlBreadcrumbLinksBuilder->getHtml();
+		$subpages .= $this->htmlBreadcrumbLinksBuilder->getHtml();
 	}
 
 	private function canModifyOutput( OutputPage $output ) {

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -75,7 +75,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 		$instance->register();
 
 		$this->doTestInitProperties( $instance );
-		$this->doTestSkinTemplateOutputPageBeforeExec( $instance, $skin );
+		$this->doTestSkinSubPageSubtitle( $instance, $skin );
 		$this->doTestBeforePageDisplay( $instance, $outputPage, $skin );
 		$this->doTestParserAfterTidy( $instance );
 		$this->doTestParserAfterTidyToBailOutEarly( $instance );
@@ -100,18 +100,18 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function doTestSkinTemplateOutputPageBeforeExec( $instance, $skin ) {
-		$handler = 'SkinTemplateOutputPageBeforeExec';
+	private function doTestSkinSubPageSubtitle( $instance, $skin ) {
+		$handler = 'SkinSubPageSubtitle';
 
 		$this->assertTrue(
 			$instance->isRegistered( $handler )
 		);
 
-		$template = new \stdClass;
+		$subpages = '';
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			[ &$skin, &$template ]
+			[ &$subpages, $skin ]
 		);
 	}
 

--- a/tests/phpunit/Unit/SkinTemplateOutputModifierTest.php
+++ b/tests/phpunit/Unit/SkinTemplateOutputModifierTest.php
@@ -245,17 +245,13 @@ class SkinTemplateOutputModifierTest extends \PHPUnit\Framework\TestCase {
 			$this->namespaceExaminer
 		);
 
-		$template = new \stdClass;
+		$subtitle = 'Foo';
 
-		$template->data = [
-			'subtitle' => 'Foo'
-		];
-
-		$instance->modify( $output, $template );
+		$instance->modify( $output, $subtitle );
 
 		$this->assertEquals(
 			'Foobar',
-			$template->data['subtitle']
+			$subtitle
 		);
 	}
 


### PR DESCRIPTION
Repull of https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/pull/78. 