### PR TITLE
Use strict semantic versioning for the version number

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,12 +1,11 @@
 This file contains the RELEASE-NOTES of the Semantic Breadcrumb Links (a.k.a. SBL) extension.
 
-### 7.0.0
+### 3.0.0
 
 Not yet released.
 
 * Added support for Semantic MediaWiki 7.0
 * Raised the minimum requirement for Semantic MediaWiki to version 7.0
-* The extension version now tracks the Semantic MediaWiki major version; this release jumps from the 2.x series to 7.0.0, skipping the unused 3.x–6.x version numbers
 * Registration now happens declaratively in `extension.json`: the settings, resource modules and extension setup moved into the manifest, so configuration defaults set in `LocalSettings.php` are honoured reliably
 
 ### 2.0.1

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.x-dev"
+			"dev-master": "3.x-dev"
 		}
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticBreadcrumbLinks",
-	"version": "7.0.0-alpha",
+	"version": "3.0.0-alpha",
 	"author": [
 		"James Hong Kong",
 		"Youri van den Bogert <yvdbogert@archixl.nl>"

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -6,14 +6,14 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 3.0.0
  *
  * @author mwjames
  */
 class Setup {
 
 	/**
-	 * @since 7.0.0
+	 * @since 3.0.0
 	 */
 	public static function onExtensionFunction() {
 		// Default values are defined at this point to ensure


### PR DESCRIPTION
## Summary

Adopt semantic versioning for the **SemanticBreadcrumbLinks** version number. Versioning the extension independently of Semantic MediaWiki lets it introduce its own breaking changes mid-cycle — between Semantic MediaWiki major releases — instead of holding them to realign its major with the next Semantic MediaWiki major.

This sets the version to the extension's own next major, `3.0.0-alpha` (branch-alias `3.x-dev`), rather than tracking the Semantic MediaWiki major. The `SemanticMediaWiki >= 7.0` requirement (the Semantic MediaWiki version this release targets) is unchanged.

## Changes

- `extension.json`: version → `3.0.0-alpha`
- `composer.json`: `extra.branch-alias.dev-master` → `3.x-dev`
- `RELEASE-NOTES.md`: heading → `3.0.0`, and drop the note that described the version tracking / mirroring the Semantic MediaWiki major
- `@since 7.0.0` docblocks updated to `@since 3.0.0` where present
